### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: "8.5"
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.3, 8.4]
+        php: [8.3, 8.4, 8.5]
         laravel: [13.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         include:


### PR DESCRIPTION
## Summary

- Added PHP 8.5 to the test matrix in `run-tests.yml` (now tests against 8.3, 8.4, and 8.5)
- Updated `phpstan.yml` to run static analysis on PHP 8.5
- No changes needed to `composer.json` — the existing `^8.3` constraint already covers 8.5

## Test plan

- [ ] Verify `run-tests` CI passes on PHP 8.5 with both Laravel 12.* and 13.*
- [ ] Verify PHPStan passes on PHP 8.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)