### PR TITLE
Resource pages to use the class from the config file

### DIFF
--- a/src/Resources/WebhookCallResource/Pages/CreateWebhookCall.php
+++ b/src/Resources/WebhookCallResource/Pages/CreateWebhookCall.php
@@ -3,9 +3,11 @@
 namespace Tapp\FilamentWebhookClient\Resources\WebhookCallResource\Pages;
 
 use Filament\Resources\Pages\CreateRecord;
-use Tapp\FilamentWebhookClient\Resources\WebhookCallResource;
 
 class CreateWebhookCall extends CreateRecord
 {
-    protected static string $resource = WebhookCallResource::class;
+    public static function getResource(): string
+    {
+        return config('filament-webhook-client.resources.WebhookCallResource');
+    }
 }

--- a/src/Resources/WebhookCallResource/Pages/EditWebhookCall.php
+++ b/src/Resources/WebhookCallResource/Pages/EditWebhookCall.php
@@ -4,11 +4,13 @@ namespace Tapp\FilamentWebhookClient\Resources\WebhookCallResource\Pages;
 
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
-use Tapp\FilamentWebhookClient\Resources\WebhookCallResource;
 
 class EditWebhookCall extends EditRecord
 {
-    protected static string $resource = WebhookCallResource::class;
+    public static function getResource(): string
+    {
+        return config('filament-webhook-client.resources.WebhookCallResource');
+    }
 
     protected function getHeaderActions(): array
     {

--- a/src/Resources/WebhookCallResource/Pages/ListWebhookCalls.php
+++ b/src/Resources/WebhookCallResource/Pages/ListWebhookCalls.php
@@ -4,11 +4,13 @@ namespace Tapp\FilamentWebhookClient\Resources\WebhookCallResource\Pages;
 
 use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ListRecords;
-use Tapp\FilamentWebhookClient\Resources\WebhookCallResource;
 
 class ListWebhookCalls extends ListRecords
 {
-    protected static string $resource = WebhookCallResource::class;
+    public static function getResource(): string
+    {
+        return config('filament-webhook-client.resources.WebhookCallResource');
+    }
 
     protected function getHeaderActions(): array
     {


### PR DESCRIPTION
Like #4 I found the resource config setting doesn't work as the pages reference the default class.

So I've updated the pages to return the configure class, so you can extend the resource and making overriding things like the resource table or infolist a lot easier:

```php
class CustomWebhookCallResource extends \Tapp\FilamentWebhookClient\Resources\WebhookCallResource
{
    public static function table(Table $table): Table
    {
        return $table
               ->columns([ ...]);
    };
};
```
Set in filament-webhook-client.php and it will use your new table correctly:
```php
  'resources' => [
        'WebhookCallResource' => CustomWebhookCallResource::class,
    ],
```

