### PR TITLE
Better default table

### DIFF
--- a/src/Resources/WebhookCallResource.php
+++ b/src/Resources/WebhookCallResource.php
@@ -11,6 +11,8 @@ use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Components\ViewEntry;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Spatie\WebhookClient\Models\WebhookCall;
@@ -96,15 +98,23 @@ class WebhookCallResource extends Resource
                 TextColumn::make('url')
                     ->sortable()
                     ->searchable(),
+                IconColumn::make('exception.code')
+                    ->label('Exception')
+                    ->boolean()
+                    ->alignCenter()
+                    ->trueIcon(Heroicon::ExclamationTriangle)
+                    ->trueColor('warning')
+                    ->toggleable(),
                 TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: true),
+                    ->toggleable(),
                 TextColumn::make('updated_at')
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
+            ->defaultSort('created_at', 'desc')
             ->filters([
                 //
             ])


### PR DESCRIPTION
A slightly opinionated PR, but the current resource table seems a bit useless to me so figured I'd suggest this change.

In my view if you're checking on webhook calls, 99% of the time you want to see what's happened with recent webhook, and usually you're looking for one that has gone wrong (so likely it has an exception).

This changes the default resource table with those expectations in mind - shows the created at field by default, and sorts most recent first. It also adds a display an icon for exceptions so you can check those first.

<img width="1130" height="340" alt="Screenshot 2026-06-30 at 17 32 36" src="https://github.com/user-attachments/assets/761424b5-41da-427f-a0d5-7198384ad3ce" />

My other pr #34 makes it easier to override the table anyway, so if this is not desired no problem, but I think it would be worth looking at how to make the table more useful by default.